### PR TITLE
Fix exist statement to use correct syntax

### DIFF
--- a/@cpplab/cpplab.m
+++ b/@cpplab/cpplab.m
@@ -51,7 +51,7 @@ methods
 		[~,~,ext]=fileparts(which('hashlib.md5hash'));
 		if ~strcmp(['.' mexext,],ext)
 			if strcmp(ext,'.m')
-				assert(exist('hashlib.md5hash.c') == 2,'Could not located hashlib.md5hash.c on the path')
+				assert(exist('+hashlib/md5hash.c') == 2,'Could not located hashlib.md5hash.c on the path')
 				InstallMex('hashlib.md5hash.c');
 			else
 				error('Could not find hashlib.md5hash on the path.')


### PR DESCRIPTION
`exist` requires file paths, dot notation is not allowed.