### PR TITLE
Cross-compatibility with Windows

### DIFF
--- a/@cpplab/resolvePath.m
+++ b/@cpplab/resolvePath.m
@@ -39,6 +39,9 @@ if nargin < 2
 	shallow = false;
 end
 
+% remove leading and trailing whitespace
+p = strip(p);
+
 
 resolved_p = [];
 cache_path = fullfile(filelib.cachePath('cpplab'), 'paths.cpplab');

--- a/@cpplab/search.m
+++ b/@cpplab/search.m
@@ -90,7 +90,11 @@ else
 				name = name(1:23);
 			else
 				padding = 23 - length(name);
-			end
+            end
+
+            if ispc
+                temp.cpp_class_path = strrep(temp.cpp_class_path, '\', '\\');
+            end
 
 			url = ['matlab:edit(' char(39) temp.cpp_class_path  char(39) ')'];
 			fprintf(['' ' <a href="' url '">' name '</a>'])

--- a/@cpplab/search.m
+++ b/@cpplab/search.m
@@ -47,12 +47,13 @@ if strcmp(pattern,'') || strcmp(pattern,'*')
 	objects = files;
 else
 
-	pattern = strrep(pattern,'/','\/');
-	pattern = strrep(pattern,'+','\+');
-
-	starts = regexpi(files, pattern);
-	iMatch = ~cellfun(@isempty, starts);
-	idx = find(iMatch);
+% 	pattern = strrep(pattern,'/','\/');
+% 	pattern = strrep(pattern,'+','\+');
+% 
+% 	starts = regexpi(files, pattern);
+% 	iMatch = ~cellfun(@isempty, starts);
+% 	idx = find(iMatch);
+    idx = contains(files, pattern);
 
 	objects = files(idx);
 


### PR DESCRIPTION
Windows doesn't like regex here, so we use the `contains` function instead. There's also an issue with trailing newlines/whitespace, which we remove by `strip`ping the queries.